### PR TITLE
Build and store artifacts

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -5,3 +5,7 @@ set -x
 export GOPATH="$(pwd)/_vendor:$GOPATH"
 
 go test -v
+
+go build -x
+
+mv nudger $CIRCLE_ARTIFACTS


### PR DESCRIPTION
Build nudger, and move it to Circle's artifacts directory for later use.
